### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/JuliansFramework/configuration.nix
+++ b/JuliansFramework/configuration.nix
@@ -28,7 +28,7 @@ in
 
 
   /* -- boot -- */
-  # config for bootloader and secure boot (refer to nixos.wiki/wiki/Secure_Boot)
+  # config for bootloader and secure boot (refer to wiki.nixos.org/wiki/Secure_Boot)
   boot = {
     kernelPackages = pkgs.linuxPackages_latest;
 

--- a/JuliansFramework/hardware-configuration.nix
+++ b/JuliansFramework/hardware-configuration.nix
@@ -20,7 +20,7 @@
       options = [ "subvol=root" ];
     };
 
-# setup luks device with yubikey as second factor (refer to nixos.wiki/wiki/Yubikey_based_Full_Disk_Encryption_(FDE)_on_NixOS)
+# setup luks device with yubikey as second factor (refer to wiki.nixos.org/wiki/Yubikey_based_Full_Disk_Encryption_(FDE)_on_NixOS)
   boot.initrd.luks = {
     yubikeySupport = true;
     devices."nixosLuks" = {

--- a/JuliansFramework/installation-script.sh
+++ b/JuliansFramework/installation-script.sh
@@ -10,7 +10,7 @@ hextorb() {
 
 : '
 This is a script that installs the system automatically for Yubikey based Full Disk Encryption
-It basically automates the process described here: https://nixos.wiki/wiki/Yubikey_based_Full_Disk_Encryption_(FDE)_on_NixOS
+It basically automates the process described here: https://wiki.nixos.org/wiki/Yubikey_based_Full_Disk_Encryption_(FDE)_on_NixOS
 Requirements:
 - Booted into NixOS ISO on target system
 - logged in as root

--- a/JuliansFramework/networking.nix
+++ b/JuliansFramework/networking.nix
@@ -8,7 +8,7 @@
       enableStrongSwan = true; # For l2tp vpn
     };
 
-    # rpfilter allow Wireguard traffic (see https://nixos.wiki/wiki/WireGuard#Setting_up_WireGuard_with_NetworkManager)
+    # rpfilter allow Wireguard traffic (see https://wiki.nixos.org/wiki/WireGuard#Setting_up_WireGuard_with_NetworkManager)
     firewall = { 
       # if packets are still dropped, they will show up in dmesg
       logReversePathDrops = true;

--- a/generic/lanzaboote.nix
+++ b/generic/lanzaboote.nix
@@ -7,7 +7,7 @@
     inputs.lanzaboote.nixosModules.lanzaboote
   ];
 
-  # config for bootloader and secure boot (refer to nixos.wiki/wiki/Secure_Boot)
+  # config for bootloader and secure boot (refer to wiki.nixos.org/wiki/Secure_Boot)
   boot = {
     bootspec.enable = true;
     loader = {


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️